### PR TITLE
修改为引用BaseObject以支持PHP 7.2

### DIFF
--- a/components/AppRoutes.php
+++ b/components/AppRoutes.php
@@ -11,14 +11,14 @@
 namespace admin\components;
 
 use yii\helpers\VarDumper;
-use yii\base\Object;
+use yii\base\BaseObject;
 use Yii;
 
 /**
  * Class AppRoutes
  * @package admin\components
  */
-class AppRoutes extends Object
+class AppRoutes extends BaseObject
 {
     /**
      * Get list of application routes


### PR DESCRIPTION
PHP 7.2已将Object作为保留字，因此引用Object会报出如下错误：
Cannot use yii\base\Object as Object because 'Object' is a special class name
因此改为引用BaseObject以兼容PHP 7.2